### PR TITLE
Rename strings MathHubData -> MathDataHub (fixes #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# MathHubData
+# MathDataHub
 
 [![Build Status](https://travis-ci.com/MathHubInfo/mhd.svg?branch=master)](https://travis-ci.com/MathHubInfo/mhd)
 
-MathHubData is a system to provide universal infrastructure for Mathematical Data. 
+MathDataHub is a system to provide universal infrastructure for Mathematical Data. 
 See the paper [Towards a Unified Mathematical Data Infrastructure: Database and Interface Generation](https://kwarc.info/people/mkohlhase/papers/cicm19-MDH.pdf)
 for more details. 
 
-This repository contains the MathHubData Implementation consisting of a [Django](https://www.djangoproject.com/)-powered backend and [create-react-app](https://github.com/facebook/create-react-app)-powered frontend. 
+This repository contains the MathDataHub Implementation consisting of a [Django](https://www.djangoproject.com/)-powered backend and [create-react-app](https://github.com/facebook/create-react-app)-powered frontend. 
+
+*Note: The code refers to the project as `mhd` (as opposed to the expected `mdh`). This is due to historical reasons.*
 
 This README contains backend information, the frontend can be found in the `frontend/` sub-folder. 
 See [frontend/README.md](frontend/README.md) for more details. 
@@ -37,7 +39,7 @@ pip install -r requirements.txt
 
 ## Development
 
-By default, MathHubData uses an `sqlite` database. 
+By default, MathDataHub uses an `sqlite` database. 
 To get started, you can run the initial migrations:
 
 ```bash

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -13,7 +13,7 @@
     </script>
     -->
 
-    <title>MathHubData</title>
+    <title>MathDataHub</title>
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -26,8 +26,8 @@
     <link rel="mask-icon" href="%PUBLIC_URL%/img/fav/safari-pinned-tab.svg" color="#ef6d4b">
 
     <!-- Manifest & Title -->
-    <meta name="apple-mobile-web-app-title" content="MathHubData">
-    <meta name="application-name" content="MathHubData">
+    <meta name="apple-mobile-web-app-title" content="MathDataHub">
+    <meta name="application-name" content="MathDataHub">
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
     

--- a/frontend/src/client/rest.d.ts
+++ b/frontend/src/client/rest.d.ts
@@ -1,6 +1,6 @@
 /** @file contains types directly returned from the REST API */
 
-/** a MathHubData Collection */
+/** a MathDataHub Collection */
 export interface TMHDCollection {
     slug: string;
     displayName: string;
@@ -24,7 +24,7 @@ export interface TMHDPreFilter {
     count: number | null,
 }
 
-/** a MathHubData Property */
+/** a MathDataHub Property */
 export interface TMHDProperty {
     slug: string;
     displayName: string;

--- a/mhd_data/apps.py
+++ b/mhd_data/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class MhdDataConfig(AppConfig):
     name = 'mhd_data'
-    verbose_name = 'MathHubData Data'
+    verbose_name = 'MathDataHub Data'

--- a/mhd_data/importers/importer.py
+++ b/mhd_data/importers/importer.py
@@ -16,7 +16,7 @@ from mhd_schema.models import Collection, Property
 
 class DataImporter(object):
     """
-        A Data Importer is an abstraction for importing data into MathHubData.
+        A Data Importer is an abstraction for importing data into MathDataHub.
 
         Does not yet support the update property
     """

--- a/mhd_provenance/apps.py
+++ b/mhd_provenance/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class MhdProvenanceConfig(AppConfig):
     name = 'mhd_provenance'
-    verbose_name = 'MathHubData Provenance'
+    verbose_name = 'MathDataHub Provenance'

--- a/mhd_schema/apps.py
+++ b/mhd_schema/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class MhdSchemaConfig(AppConfig):
     name = 'mhd_schema'
-    verbose_name = 'MathHubData Schema'
+    verbose_name = 'MathDataHub Schema'


### PR DESCRIPTION
This PR replaces the string "MathHubData" to "DataMathHub" where applicable, effectively renaming the project. 
All identifiers, database and code references continue to use the abbreviation `mhd`, in order not to break existing code and production instances.